### PR TITLE
fixed FileAssociatedShader "incompatibility" with vim

### DIFF
--- a/source/FileAssociatedShader.cpp
+++ b/source/FileAssociatedShader.cpp
@@ -3,6 +3,7 @@
 #include <QFileSystemWatcher>
 #include <QTextStream>
 #include <QFileInfo>
+#include <QStringList>
 #include "FileAssociatedShader.h"
 
 QMap<QString, QOpenGLShader *> FileAssociatedShader::s_shaderByFilePath;
@@ -118,6 +119,21 @@ void FileAssociatedShader::programDestroyed(QObject * object)
 QList<QOpenGLShaderProgram *> FileAssociatedShader::process()
 {
     QList<QOpenGLShaderProgram *> programsWithInvalidatedUniforms;
+
+	{
+		auto inst = static_cast<FileAssociatedShader*>(instance());
+		auto watchedFiles = inst->fileSystemWatcher()->files();
+		if (watchedFiles.count() != inst->s_shaderByFilePath.count())
+		{
+			for (auto path : inst->s_shaderByFilePath.keys())
+			{
+				if (!watchedFiles.contains(path) && QFileInfo(path).exists())
+				{
+					inst->m_fileSystemWatcher->addPath(path);
+				}
+			}
+		}
+	}
 
     while (!s_queue.isEmpty())
     {


### PR DESCRIPTION
Vim does not always simply write to the saved file but replaces them with its swap file.
The removal of the shader source file would cause QFileSystemWatcher to unwatch it.
Hence, editing shader source files with vim would break the intended behavior.

This pull request comprises the code I used to fix it. Maybe you have a better solution or want to adapt it somehow. In this case, treat this as a bug report or vim-support feature request, please.
